### PR TITLE
Improved check for allowance

### DIFF
--- a/data.rs
+++ b/data.rs
@@ -263,7 +263,8 @@ impl PSP34Data {
     /// the operator is approved to withdraw all owner's tokens.
     pub fn allowance(&self, owner: AccountId, operator: AccountId, id: Option<Id>) -> bool {
         match id {
-            Some(token) => self.is_allowed_single(owner, operator, token),
+            Some(token) => self.is_allowed_single(owner, operator, token)
+                        || self.is_allowed_all(owner, operator),
             None => self.is_allowed_all(owner, operator),
         }
     }


### PR DESCRIPTION
Key points

- If approval is given for all 'Id's, checking a single token Id in every instance should return true whether or not the single token Id is approved.